### PR TITLE
Add support for GitLab

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ As a package maintainer, it's a challenging task to keep track of every new rele
 ### Supported Providers
 * CPAN
 * Github (with API Key support)
+* GitLab
 * GNOME
 * Hackage
 * Jetbrains
@@ -32,7 +33,6 @@ As a package maintainer, it's a challenging task to keep track of every new rele
 * BitBucket
 * FTP
 * Git
-* GitLab
 
 ### Stretch Goal Providers
 * RSS
@@ -90,6 +90,7 @@ where CMD is the action to perform and URL is the link to an existing source.
 | --------- | --- |
 | CPAN      | https://cpan.metacpan.org/authors/id/T/TO/TODDR/IO-1.39.tar.gz |
 | Github    | https://github.com/DataDrake/cuppa/archive/v1.0.4.tar.gz |
+| GitLab    | https://gitlab.com/corectrl/corectrl/-/archive/v1.0.6/corectrl-v1.0.6.tar.gz |
 | GNOME     | https://download.gnome.org/sources/gnome-music/3.28/gnome-music-3.28.2.tar.xz |
 | Hackage   | https://hackage.haskell.org/package/mtl-2.2.2/mtl-2.2.2.tar.gz |
 | JetBrains | https://download.jetbrains.com/ruby/RubyMine-2017.3.3.tar.gz |

--- a/providers/gitlab/provider.go
+++ b/providers/gitlab/provider.go
@@ -1,0 +1,128 @@
+//
+// Copyright 2016-2018 Bryan T. Meyers <bmeyers@datadrake.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package gitlab
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/DataDrake/cuppa/results"
+)
+
+const (
+	// SourceFormat is the format string for GitLab release tarballs
+	SourceFormat = "https://gitlab.com/%s/-/archive/%s/%s.tar.gz"
+
+	// TagsEndpoint is the API endpoint URL for GitLab project tags
+	TagsEndpoint = "https://gitlab.com/api/v4/projects/%s/repository/tags"
+)
+
+// SourceRegex is the regex for GitLab sources
+var SourceRegex = regexp.MustCompile("gitlab.com/([^/]+/[^/.]+)")
+
+// VersionRegex is used to parse GitLab version numbers
+var VersionRegex = regexp.MustCompile("(?:\\d+\\.)*\\d+\\w*")
+
+// Provider is the upstream provider interface for GitLab
+type Provider struct{}
+
+// Latest finds the newest release for a GitLab package
+func (c Provider) Latest(name string) (r *results.Result, s results.Status) {
+	rs, s := c.Releases(name)
+	if s != results.OK {
+		return
+	}
+	r = rs.Last()
+	return
+}
+
+// Match checks to see if this provider can handle this kind of query
+func (c Provider) Match(query string) string {
+	sm := SourceRegex.FindStringSubmatch(query)
+	if len(sm) != 2 {
+		return ""
+	}
+	return sm[1]
+}
+
+// Name gives the name of this provider
+func (c Provider) Name() string {
+	return "GitLab"
+}
+
+// Releases finds all matching releases for a github package
+func (c Provider) Releases(name string) (rs *results.ResultSet, s results.Status) {
+	// Query the API
+	encoded := strings.Replace(name, "/", "%2f", 1)
+	resp, err := http.Get(fmt.Sprintf(TagsEndpoint, encoded))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		s = results.Unavailable
+		return
+	}
+
+	defer resp.Body.Close()
+	// Translate Status Code
+	switch resp.StatusCode {
+	case 200:
+		s = results.OK
+	case 404:
+		s = results.NotFound
+	default:
+		s = results.Unavailable
+	}
+
+	// Fail if not OK
+	if s != results.OK {
+		return
+	}
+
+	dec := json.NewDecoder(resp.Body)
+	raw := make([]interface{}, 0)
+	err = dec.Decode(&raw)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		s = results.Unavailable
+		return
+	}
+
+	if len(raw) < 1 {
+		s = results.Unavailable
+		return
+	}
+
+	rs = results.NewResultSet(name)
+	for _, v := range raw {
+		tag := v.(map[string]interface{})["name"]
+		file := fmt.Sprintf("%s-%s", strings.Split(name, "/")[1], tag)
+		loc := fmt.Sprintf(SourceFormat, name, tag, file)
+
+		commit := v.(map[string]interface{})["commit"].(map[string]interface{})
+		date := commit["authored_date"]
+		published, _ := time.Parse(time.RFC3339, date.(string))
+
+		r := results.NewResult(name, tag.(string), loc, published)
+		rs.AddResult(r)
+	}
+
+	return
+}

--- a/providers/gitlab/tag.go
+++ b/providers/gitlab/tag.go
@@ -1,0 +1,52 @@
+//
+// Copyright 2016-2018 Bryan T. Meyers <bmeyers@datadrake.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package gitlab
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/DataDrake/cuppa/results"
+)
+
+// Commit is a JSON representation of a GitLab commit
+type Commit struct {
+	AuthoredDate string `json:"authored_date"`
+}
+
+// Release is a JSON representation of a GitLab tag release
+type Release struct {
+	TagName     string `json:"tag_name"`
+	Description string `json:"description"`
+}
+
+// Tag is a JSON representation of a GitLab tag
+type Tag struct {
+	Name    string  `json:"name"`
+	Commit  Commit  `json:"commit"`
+	Release Release `json:"release"`
+}
+
+// Convert turns a GitLab tag into a Cuppa result
+func (gl Tag) Convert(name string) *results.Result {
+	published, _ := time.Parse(time.RFC3339, gl.Commit.AuthoredDate)
+	file := fmt.Sprintf("%s-%s", strings.Split(name, "/")[1], gl.Name)
+	loc := fmt.Sprintf(SourceFormat, name, gl.Name, file)
+
+	return results.NewResult(name, gl.Release.TagName, loc, published)
+}

--- a/providers/gitlab/tags.go
+++ b/providers/gitlab/tags.go
@@ -1,0 +1,37 @@
+//
+// Copyright 2016-2018 Bryan T. Meyers <bmeyers@datadrake.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package gitlab
+
+import "github.com/DataDrake/cuppa/results"
+
+// Tags is a set of one or more GitLab tags
+type Tags struct {
+	Tags []Tag
+}
+
+// Convert turns a GitLab result set into a Cuppa ResultSet
+func (gls Tags) Convert(name string) *results.ResultSet {
+	rs := results.NewResultSet(name)
+	for _, rel := range gls.Tags {
+		r := rel.Convert(name)
+		if r != nil {
+			rs.AddResult(r)
+		}
+	}
+
+	return rs
+}

--- a/providers/provider.go
+++ b/providers/provider.go
@@ -20,6 +20,7 @@ import (
 	"github.com/DataDrake/cuppa/providers/cpan"
 	"github.com/DataDrake/cuppa/providers/git"
 	"github.com/DataDrake/cuppa/providers/github"
+	"github.com/DataDrake/cuppa/providers/gitlab"
 	"github.com/DataDrake/cuppa/providers/gnome"
 	"github.com/DataDrake/cuppa/providers/gnu"
 	"github.com/DataDrake/cuppa/providers/hackage"
@@ -57,5 +58,6 @@ func All() []Provider {
 		rubygems.Provider{},
 		sourceforge.Provider{},
 		git.Provider{},
+		gitlab.Provider{},
 	}
 }


### PR DESCRIPTION
Adds support for GitLab sources.

If there is a cleaner way to do any of this, please let me know; I'm still pretty new to Go. But, it works and is still pretty readable, at least to me.

The GitLab docs say that there is a GraphQL API, but as far as I can tell, you can't get any sort of release or tag data from it.