### PR TITLE
Move Freedesktop support into the GitLab provider

### DIFF
--- a/providers/gitlab/tags.go
+++ b/providers/gitlab/tags.go
@@ -16,7 +16,9 @@
 
 package gitlab
 
-import "github.com/DataDrake/cuppa/results"
+import (
+	"github.com/DataDrake/cuppa/results"
+)
 
 // Tags is a set of one or more GitLab tags
 type Tags struct {
@@ -24,10 +26,10 @@ type Tags struct {
 }
 
 // Convert turns a GitLab result set into a Cuppa ResultSet
-func (gls Tags) Convert(name string) *results.ResultSet {
+func (gls Tags) Convert(name string, isFreedesktop bool) *results.ResultSet {
 	rs := results.NewResultSet(name)
 	for _, rel := range gls.Tags {
-		r := rel.Convert(name)
+		r := rel.Convert(name, isFreedesktop)
 		if r != nil {
 			rs.AddResult(r)
 		}

--- a/providers/html/upstreams.go
+++ b/providers/html/upstreams.go
@@ -22,11 +22,6 @@ import (
 
 var upstreams = []Upstream{
 	{
-		Name:        "freedesktop",
-		HostPattern: regexp.MustCompile("^(https?://.*freedesktop.org/.+\\/)([^\\/]+)-.+?$"),
-		Conf:        HTTPDConfig,
-	},
-	{
 		Name:        "xorg",
 		HostPattern: regexp.MustCompile("^(https?://.*x.org/.+\\/)([^\\/]+)-.+?$"),
 		Conf:        HTTPDConfig,

--- a/results/result.go
+++ b/results/result.go
@@ -18,9 +18,10 @@ package results
 
 import (
 	"fmt"
-	"github.com/DataDrake/cuppa/version"
 	"strings"
 	"time"
+
+	"github.com/DataDrake/cuppa/version"
 )
 
 // Result contains the information for a single query result


### PR DESCRIPTION
Freedesktop support now lives in the GitLab provider, and the provider picks which endpoint to use based on the hostname. Matching will work regardless of the archive format passed to cuppa, if one is given at all; it will return the bzipped sources in all cases.

This also fixes an issue where it breaks for certain GitLab projects because no JSON object for a tag's release is returned for the query.