### PR TITLE
Allow the use of Cuppa Without a Config File.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -17,10 +17,12 @@
 package config
 
 import (
-	"github.com/BurntSushi/toml"
-	log "github.com/DataDrake/waterlog"
 	"os/user"
 	"path/filepath"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+	log "github.com/DataDrake/waterlog"
 )
 
 // Config is the configuration for cuppa
@@ -40,7 +42,8 @@ func init() {
 		return
 	}
 	configPath := filepath.Join(user.HomeDir, ".config", "cuppa")
-	if _, err = toml.DecodeFile(configPath, &Global); err != nil {
+	if _, err = toml.DecodeFile(configPath, &Global); err != nil &&
+		!strings.HasSuffix(err.Error(), "no such file or directory") {
 		log.Fatalf("Failed to read config, reason: '%s'\n", err)
 	}
 }


### PR DESCRIPTION
As is `toml.DecodeFile()` will return an error if the config file for the GitHub token does not exist. To allow users not interested in GitHub queries to continue using the app we should not halt the execution of the application if the config file does not exist. We could instead replace this `log.Fatal()` with a `log.Println()` however, If we still print the error anyone using cuppa as a library will have the application printing to the console in the middle of their own application.